### PR TITLE
Refresh repository status during deployment

### DIFF
--- a/src/airflow_multirepo_deploy/plugin.py
+++ b/src/airflow_multirepo_deploy/plugin.py
@@ -135,6 +135,20 @@ def _git_env(dags_folder, folder: str) -> dict:
     return env
 
 
+def _repo_meta_to_dict(repo_meta: RepoMeta) -> dict:
+    return {
+        "folder": repo_meta.folder,
+        "active_branch": repo_meta.active_branch,
+        "committed_date_str": repo_meta.committed_date_str,
+        "sha": repo_meta.sha,
+        "author": repo_meta.author,
+        "commit_message": repo_meta.commit_message,
+        "remotes": repo_meta.remotes,
+        "local_branches": repo_meta.local_branches,
+        "remote_branches": repo_meta.remote_branches,
+    }
+
+
 def _load_repo(path, folder) -> RepoMeta | bool:
     try:
         return RepoMeta.from_repo(Repo(path), folder)
@@ -254,22 +268,34 @@ async def deploy_repo(request: Request, folder: str, branches: str = Form(...)):
     new_branch = branches
     new_local_branch = "/".join(new_branch.split("/")[1:])
     git_env = _git_env(DAGS_FOLDER, folder)
+    folder_path = Path(DAGS_FOLDER).joinpath(folder)
 
     try:
         repo.git.checkout(new_local_branch, env=git_env)
         repo.remotes.origin.fetch(env=git_env)
         repo.git.reset("--hard", f"origin/{new_local_branch}", env=git_env)
+    except (GitCommandError, Exception) as exc:
+        # Git failed — local repo state is unchanged, no repo update needed
+        return JSONResponse({"error": traceback.format_exception(exc), "repo": None}, status_code=400)
+
+    try:
         post_hook = get_post_hook()
         if post_hook:
-            resp = post_hook(Path(DAGS_FOLDER).joinpath(folder))
+            resp = post_hook(folder_path)
             if isawaitable(resp):
                 await resp
-    except (GitCommandError, Exception) as exc:
-        error_message = traceback.format_exception(exc)
+    except Exception as exc:
+        # Post hook failed — git reset already applied, return updated repo state
+        repo_meta = _load_repo(folder_path, folder)
+        return JSONResponse(
+            {"error": traceback.format_exception(exc), "repo": _repo_meta_to_dict(repo_meta) if repo_meta else None},
+            status_code=400,
+        )
 
-        return JSONResponse({"error": error_message}, status_code=400)
-
-    return JSONResponse({"success": "Deployment successful"})
+    repo_meta = _load_repo(folder_path, folder)
+    return JSONResponse(
+        {"success": "Deployment successful", "repo": _repo_meta_to_dict(repo_meta) if repo_meta else None}
+    )
 
 
 def _get_github_app_token():

--- a/src/airflow_multirepo_deploy/ui/src/pages/Deploy.tsx
+++ b/src/airflow_multirepo_deploy/ui/src/pages/Deploy.tsx
@@ -44,6 +44,7 @@ interface DeployPageData {
 interface DeployResponse {
   success?: string;
   errors?: string[];
+  repo?: Repository | null;
 }
 
 export const Deploy = () => {
@@ -120,6 +121,9 @@ export const Deploy = () => {
       if (response.ok) {
         const result = await response.json();
         setDeployResponse({ success: result.success || "Deployment successful!" });
+        if (result.repo && data) {
+          setData({ ...data, repo: result.repo });
+        }
       } else {
         const result = await response.json();
         // Handle both string errors and array-of-strings error format
@@ -127,6 +131,10 @@ export const Deploy = () => {
         setDeployResponse({
           errors: Array.isArray(errorData) ? [errorData.join("")] : [errorData],
         });
+        // Post hook failure: git state changed, repo is returned — refresh details
+        if (result.repo && data) {
+          setData({ ...data, repo: result.repo });
+        }
       }
     } catch (err) {
       setDeployResponse({


### PR DESCRIPTION
This pull request improves the deployment workflow by providing more detailed feedback on repository state after deployment attempts, especially when errors occur. The backend now consistently returns updated repository metadata after both successful deployments and certain failure scenarios, and the frontend updates its state accordingly to reflect the latest repository information.

**Backend enhancements to deployment response:**

* Added a helper function `_repo_meta_to_dict` to serialize `RepoMeta` objects for API responses, ensuring consistent structure for repository metadata.
* Updated the `deploy_repo` endpoint to always include the latest repository metadata (`repo`) in the JSON response after deployment attempts, whether successful or if the post hook fails. This allows the frontend to display the most current repo state.

**Frontend updates for repository state management:**

* Extended the `DeployResponse` interface to optionally include a `repo` field, allowing the frontend to receive and process repository metadata from the backend.
* Modified the deployment logic in `Deploy.tsx` to update the UI's repository state (`data.repo`) with the latest metadata returned from the backend after both successful deployments and post hook failures.